### PR TITLE
Use scoped storage APIs

### DIFF
--- a/app/src/main/java/info/cgslab/burstiblshooter/CameraFragment.java
+++ b/app/src/main/java/info/cgslab/burstiblshooter/CameraFragment.java
@@ -39,8 +39,6 @@ import java.util.List;
 import timber.log.Timber;
 
 public class CameraFragment extends Fragment {
-    public static final String DCIM = Environment.getExternalStoragePublicDirectory(
-            Environment.DIRECTORY_DCIM).getPath();
     public static final String FILENAME = "fileName";
     public String SAVEDIR = "";
     private SurfaceHolder mSurfaceHolder;
@@ -169,7 +167,7 @@ public class CameraFragment extends Fragment {
              * The following DNG file is output by enabling DNG output and executing still image shooting.
              */
             ///DCIM/0/temp0.dng
-            File dngTempFile = dngTempFile = new File(Environment.getExternalStorageDirectory().getPath() + "/temp" + dngcount + ".dng");
+            File dngTempFile = new File(getContext().getExternalFilesDir(null).getPath() + "/temp" + dngcount + ".dng");
             String dngFileUrl = fileUrl.replace(".JPG", ".DNG");
             fileUrls.add(dngFileUrl);
             /**
@@ -304,7 +302,9 @@ public class CameraFragment extends Fragment {
         DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmm_ss");
         Date date = new Date();
         String dateToStr = dateFormat.format(date);
-        SAVEDIR = DCIM + "/Burst_IBL_Shooter/" + "BIS_" + dateToStr;
+        File dcimDir = getContext().getExternalFilesDir(Environment.DIRECTORY_DCIM);
+        String dcimPath = (dcimDir != null) ? dcimDir.getPath() : "";
+        SAVEDIR = dcimPath + "/Burst_IBL_Shooter/" + "BIS_" + dateToStr;
         File newDir = new File(SAVEDIR);
         newDir.mkdirs();
     }

--- a/app/src/main/java/info/cgslab/burstiblshooter/MainActivity.java
+++ b/app/src/main/java/info/cgslab/burstiblshooter/MainActivity.java
@@ -33,6 +33,7 @@ import com.theta360.pluginlibrary.values.LedTarget;
 import com.theta360.pluginlibrary.values.OledDisplay;
 import com.theta360.pluginlibrary.values.TextArea;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -114,7 +115,8 @@ public class MainActivity extends PluginActivity implements CameraFragment.CFCal
          * specifies the file path or directory path under the DCIM directory.
          * Replace file path because fileUrls has full path set
          */
-        String storagePath = Environment.getExternalStorageDirectory().getPath();
+        File dcimDir = getExternalFilesDir(Environment.DIRECTORY_DCIM);
+        String storagePath = dcimDir != null ? dcimDir.getParent() : "";
         for (int i = 0; i < fileUrls.length; i++) {
             fileUrls[i] = fileUrls[i].replace(storagePath, "");
         }


### PR DESCRIPTION
## Summary
- replace legacy external storage paths with scoped `getExternalFilesDir` usage
- adjust path handling for `notificationDatabaseUpdate`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bda2060c832183742aa1e77755ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when saving photos/DNG files by using the app-specific DCIM directory.
  - Fixed path handling to ensure files appear consistently in file managers and galleries.
- Chores
  - Updated storage path management to align with modern Android scoped storage guidelines, reducing reliance on device-wide directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->